### PR TITLE
Add Vitest setup and initial logger tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,9 @@
       "devDependencies": {
         "asar": "^3.2.0",
         "electron": "^38.2.0",
-        "electron-builder": "^25.1.8"
+        "electron-builder": "^25.1.8",
+        "vitest": "^1.6.0",
+        "@vitest/coverage-v8": "^1.6.0"
       }
     },
     "node_modules/@develar/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/documental/app-git-electron",
   "scripts": {
     "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "build": "electron-builder",
     "build:linux": "electron-builder --linux",
     "build:linux:deb": "electron-builder --linux deb",
@@ -34,7 +34,9 @@
   "devDependencies": {
     "asar": "^3.2.0",
     "electron": "^38.2.0",
-    "electron-builder": "^25.1.8"
+    "electron-builder": "^25.1.8",
+    "vitest": "^1.6.0",
+    "@vitest/coverage-v8": "^1.6.0"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.0",

--- a/tests/main/logger.test.cjs
+++ b/tests/main/logger.test.cjs
@@ -1,0 +1,63 @@
+const { describe, it, expect } = require('vitest');
+const {
+  loadMainProcess,
+  getIpcHandler,
+  electronMock,
+  createWindowMock
+} = require('../setup/helpers.cjs');
+
+describe('main process logger', () => {
+  it('buffers log entries and exposes them through the get-app-logs handler', async () => {
+    loadMainProcess();
+
+    const getLogsHandler = getIpcHandler('get-app-logs');
+    expect(getLogsHandler).toBeTypeOf('function');
+
+    console.log('first message');
+    console.error('second message');
+
+    const logs = await getLogsHandler();
+
+    expect(logs).toContain('first message');
+    expect(logs).toContain('second message');
+  });
+
+  it('keeps only the most recent messages within the buffer limit', async () => {
+    loadMainProcess();
+
+    const getLogsHandler = getIpcHandler('get-app-logs');
+    expect(getLogsHandler).toBeTypeOf('function');
+
+    const totalEntries = 10005;
+    for (let index = 0; index < totalEntries; index += 1) {
+      console.log(`buffer-entry-${index}`);
+    }
+
+    const logs = await getLogsHandler();
+    const entries = logs.trim().split('\n');
+
+    expect(entries.length).toBeLessThanOrEqual(10000);
+    expect(entries[0]).toContain('buffer-entry-5');
+    expect(entries[entries.length - 1]).toContain('buffer-entry-10004');
+  });
+
+  it('broadcasts each log entry to every available BrowserWindow', () => {
+    loadMainProcess();
+
+    const windowA = createWindowMock();
+    const windowB = createWindowMock();
+
+    electronMock.BrowserWindow.getAllWindows.mockReturnValue([windowA, windowB]);
+
+    console.log('broadcast-test');
+
+    expect(windowA.webContents.send).toHaveBeenCalledWith(
+      'app-log-output',
+      expect.stringContaining('broadcast-test')
+    );
+    expect(windowB.webContents.send).toHaveBeenCalledWith(
+      'app-log-output',
+      expect.stringContaining('broadcast-test')
+    );
+  });
+});

--- a/tests/setup/helpers.cjs
+++ b/tests/setup/helpers.cjs
@@ -1,0 +1,32 @@
+const path = require('path');
+const {
+  electronMock,
+  fsMock,
+  childProcessMock,
+  createWindowMock
+} = require('./mocks.cjs');
+
+function loadMainProcess() {
+  const mainPath = path.resolve(__dirname, '../../main.js');
+  delete require.cache[mainPath];
+  return require(mainPath);
+}
+
+function getIpcHandler(channel) {
+  const calls = electronMock.ipcMain.handle.mock.calls;
+  for (const call of calls) {
+    if (call[0] === channel) {
+      return call[1];
+    }
+  }
+  return undefined;
+}
+
+module.exports = {
+  loadMainProcess,
+  getIpcHandler,
+  electronMock,
+  fsMock,
+  childProcessMock,
+  createWindowMock
+};

--- a/tests/setup/index.cjs
+++ b/tests/setup/index.cjs
@@ -1,0 +1,28 @@
+const path = require('path');
+const { beforeEach, afterEach, vi } = require('vitest');
+const { electronMock, fsMock, childProcessMock, resetAllMocks } = require('./mocks.cjs');
+
+vi.mock('electron', () => electronMock);
+vi.mock('fs', () => fsMock);
+vi.mock('child_process', () => childProcessMock);
+
+const originalConsole = {
+  log: console.log,
+  error: console.error,
+  warn: console.warn,
+  info: console.info
+};
+
+beforeEach(() => {
+  resetAllMocks();
+});
+
+afterEach(() => {
+  const mainPath = path.resolve(__dirname, '../../main.js');
+  delete require.cache[mainPath];
+
+  console.log = originalConsole.log;
+  console.error = originalConsole.error;
+  console.warn = originalConsole.warn;
+  console.info = originalConsole.info;
+});

--- a/tests/setup/mocks.cjs
+++ b/tests/setup/mocks.cjs
@@ -1,0 +1,179 @@
+const { vi } = require('vitest');
+const actualFs = require('fs');
+
+const resetters = [];
+
+function createMockFn(defaultImpl) {
+  const fn = defaultImpl ? vi.fn(defaultImpl) : vi.fn();
+  resetters.push(() => {
+    fn.mockReset();
+    if (defaultImpl) {
+      fn.mockImplementation(defaultImpl);
+    }
+  });
+  return fn;
+}
+
+function createStreamMock() {
+  return {
+    on: createMockFn(),
+    once: createMockFn(),
+    emit: createMockFn(),
+    end: createMockFn(),
+    destroy: createMockFn(),
+    close: createMockFn(),
+    pipe: createMockFn()
+  };
+}
+
+function createElectronMock() {
+  const browserWindowConstructor = createMockFn(() => {
+    return {
+      loadURL: createMockFn(),
+      loadFile: createMockFn(),
+      on: createMockFn(),
+      once: createMockFn(),
+      show: createMockFn(),
+      hide: createMockFn(),
+      close: createMockFn(),
+      focus: createMockFn(),
+      setBrowserView: createMockFn(),
+      removeBrowserView: createMockFn(),
+      setBounds: createMockFn(),
+      setMenuBarVisibility: createMockFn(),
+      webContents: {
+        send: createMockFn(),
+        on: createMockFn(),
+        once: createMockFn(),
+        openDevTools: createMockFn(),
+        close: createMockFn()
+      },
+      isDestroyed: createMockFn(() => false)
+    };
+  });
+
+  browserWindowConstructor.getAllWindows = createMockFn(() => []);
+  browserWindowConstructor.fromWebContents = createMockFn(() => null);
+
+  return {
+    app: {
+      getPath: createMockFn(() => '/tmp/documental'),
+      on: createMockFn(),
+      once: createMockFn(),
+      whenReady: createMockFn(() => Promise.resolve()),
+      isReady: createMockFn(() => false),
+      quit: createMockFn(),
+      removeListener: createMockFn(),
+      removeAllListeners: createMockFn()
+    },
+    BrowserWindow: browserWindowConstructor,
+    BrowserView: createMockFn(() => ({
+      setBounds: createMockFn(),
+      setAutoResize: createMockFn(),
+      webContents: {
+        loadURL: createMockFn(),
+        on: createMockFn(),
+        once: createMockFn(),
+        send: createMockFn(),
+        openDevTools: createMockFn(),
+        close: createMockFn()
+      }
+    })),
+    ipcMain: {
+      handle: createMockFn(),
+      handleOnce: createMockFn(),
+      on: createMockFn(),
+      once: createMockFn(),
+      removeHandler: createMockFn(),
+      removeListener: createMockFn(),
+      removeAllListeners: createMockFn()
+    },
+    Menu: {
+      setApplicationMenu: createMockFn(),
+      buildFromTemplate: createMockFn()
+    },
+    dialog: {
+      showOpenDialog: createMockFn(async () => ({ canceled: true, filePaths: [] })),
+      showMessageBox: createMockFn(async () => ({ response: 0 })),
+      showErrorBox: createMockFn()
+    },
+    shell: {
+      openExternal: createMockFn(),
+      openPath: createMockFn()
+    }
+  };
+}
+
+function createFsMock() {
+  const stubs = {
+    existsSync: createMockFn(() => false),
+    readFileSync: createMockFn(() => ''),
+    writeFileSync: createMockFn(),
+    mkdirSync: createMockFn(),
+    rmSync: createMockFn(),
+    readdirSync: createMockFn(() => []),
+    statSync: createMockFn(() => ({
+      isDirectory: () => false,
+      isFile: () => true
+    })),
+    readlinkSync: createMockFn(() => ''),
+    createWriteStream: createMockFn(() => createStreamMock()),
+    createReadStream: createMockFn(() => createStreamMock()),
+    renameSync: createMockFn(),
+    copyFileSync: createMockFn()
+  };
+
+  return new Proxy({}, {
+    get(_, prop) {
+      if (prop in stubs) {
+        return stubs[prop];
+      }
+      return actualFs[prop];
+    }
+  });
+}
+
+function createChildProcessMock() {
+  return {
+    spawn: createMockFn(() => ({
+      stdout: {
+        on: createMockFn()
+      },
+      stderr: {
+        on: createMockFn()
+      },
+      on: createMockFn()
+    })),
+    execSync: createMockFn(() => '')
+  };
+}
+
+function createWindowMock() {
+  return {
+    isDestroyed: createMockFn(() => false),
+    webContents: {
+      send: createMockFn(),
+      on: createMockFn(),
+      once: createMockFn(),
+      openDevTools: createMockFn(),
+      close: createMockFn()
+    }
+  };
+}
+
+function resetAllMocks() {
+  vi.clearAllMocks();
+  resetters.forEach(reset => reset());
+}
+
+const electronMock = createElectronMock();
+const fsMock = createFsMock();
+const childProcessMock = createChildProcessMock();
+
+module.exports = {
+  electronMock,
+  fsMock,
+  childProcessMock,
+  createWindowMock,
+  resetAllMocks
+};

--- a/vitest.config.cjs
+++ b/vitest.config.cjs
@@ -1,0 +1,14 @@
+const { defineConfig } = require('vitest/config');
+const path = require('path');
+
+module.exports = defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.cjs'],
+    setupFiles: [path.resolve(__dirname, 'tests/setup/index.cjs')],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov']
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest as the project test runner and enable V8 coverage reporting
- add shared Electron, fs, and child_process mocks plus helpers for main-process testing
- create foundational logger tests that exercise buffering and broadcast behaviour

## Testing
- npm test *(fails: Vitest CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108dccc0fc8333b9b457177ebe4e0f)