### PR TITLE
Refactor main bootstrap and logging

### DIFF
--- a/src/main/bootstrap/app.js
+++ b/src/main/bootstrap/app.js
@@ -1,0 +1,43 @@
+function bootstrapApp({
+  app,
+  createWindow,
+  initializeDatabase,
+  registerHandlers,
+  onActivate,
+  onBeforeQuit,
+  onWindowAllClosed
+} = {}) {
+  if (!app || typeof app.whenReady !== 'function') {
+    throw new Error('Electron app instance with whenReady is required');
+  }
+  if (typeof createWindow !== 'function') {
+    throw new Error('createWindow function is required');
+  }
+  if (typeof initializeDatabase !== 'function') {
+    throw new Error('initializeDatabase function is required');
+  }
+
+  app.whenReady().then(async () => {
+    await createWindow();
+    await initializeDatabase();
+    if (typeof registerHandlers === 'function') {
+      registerHandlers();
+    }
+  });
+
+  if (typeof onActivate === 'function') {
+    app.on('activate', onActivate);
+  }
+
+  if (typeof onBeforeQuit === 'function') {
+    app.on('before-quit', onBeforeQuit);
+  }
+
+  if (typeof onWindowAllClosed === 'function') {
+    app.on('window-all-closed', onWindowAllClosed);
+  }
+}
+
+module.exports = {
+  bootstrapApp
+};

--- a/src/main/logging/logger.js
+++ b/src/main/logging/logger.js
@@ -1,0 +1,88 @@
+const DEFAULT_MAX_LOG_BUFFER_SIZE = 10000;
+
+function createLogger({ BrowserWindow, maxBufferSize = DEFAULT_MAX_LOG_BUFFER_SIZE } = {}) {
+  if (!BrowserWindow || typeof BrowserWindow.getAllWindows !== 'function') {
+    throw new Error('BrowserWindow with getAllWindows method is required');
+  }
+
+  let appLogBuffer = [];
+
+  const originalConsole = {
+    log: console.log.bind(console),
+    error: console.error.bind(console),
+    warn: console.warn.bind(console),
+    info: console.info.bind(console)
+  };
+
+  function broadcastLogEntry(entry) {
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach(window => {
+      if (window && typeof window.isDestroyed === 'function' && !window.isDestroyed()) {
+        const { webContents } = window;
+        if (webContents && typeof webContents.send === 'function') {
+          webContents.send('app-log-output', entry);
+        }
+      }
+    });
+  }
+
+  function formatLogEntry(level, args) {
+    const timestamp = new Date().toISOString();
+    const message = args.map(arg =>
+      typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
+    ).join(' ');
+
+    return `[${timestamp}] [${level.toUpperCase()}] ${message}\n`;
+  }
+
+  function addToAppLog(level, ...args) {
+    const entry = formatLogEntry(level, args);
+
+    appLogBuffer.push(entry);
+    if (appLogBuffer.length > maxBufferSize) {
+      appLogBuffer = appLogBuffer.slice(-maxBufferSize);
+    }
+
+    broadcastLogEntry(entry);
+  }
+
+  function overrideConsole(methodName, level) {
+    console[methodName] = (...args) => {
+      addToAppLog(level, ...args);
+      originalConsole[methodName](...args);
+    };
+  }
+
+  overrideConsole('log', 'info');
+  overrideConsole('error', 'error');
+  overrideConsole('warn', 'warn');
+  overrideConsole('info', 'info');
+
+  function getAppLogs() {
+    return appLogBuffer.join('');
+  }
+
+  function restoreConsole() {
+    console.log = originalConsole.log;
+    console.error = originalConsole.error;
+    console.warn = originalConsole.warn;
+    console.info = originalConsole.info;
+  }
+
+  function getLogBufferSnapshot() {
+    return [...appLogBuffer];
+  }
+
+  return {
+    addToAppLog,
+    getAppLogs,
+    restoreConsole,
+    getLogBufferSnapshot,
+    maxBufferSize
+  };
+}
+
+module.exports = {
+  createLogger,
+  DEFAULT_MAX_LOG_BUFFER_SIZE
+};

--- a/src/main/processes/documentalTracker.js
+++ b/src/main/processes/documentalTracker.js
@@ -1,0 +1,111 @@
+function createDocumentalTracker({ fs, path, processesFilePath } = {}) {
+  if (!fs) {
+    throw new Error('fs dependency is required');
+  }
+
+  if (!path || typeof path.join !== 'function') {
+    throw new Error('path dependency is required');
+  }
+
+  const filePath = processesFilePath || path.join(process.cwd(), 'documental-processes.json');
+
+  let activeProcesses = {};
+
+  function loadProcesses() {
+    try {
+      if (fs.existsSync(filePath)) {
+        const data = fs.readFileSync(filePath, 'utf8');
+        activeProcesses = JSON.parse(data);
+        console.log('📂 Loaded Documental processes from file:', Object.keys(activeProcesses));
+      } else {
+        activeProcesses = {};
+      }
+    } catch (error) {
+      console.error('Error loading Documental processes:', error);
+      activeProcesses = {};
+    }
+
+    return getProcessesSnapshot();
+  }
+
+  function persistProcesses() {
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(activeProcesses, null, 2));
+      console.log('💾 Saved Documental processes to file');
+    } catch (error) {
+      console.error('Error saving Documental processes:', error);
+    }
+  }
+
+  function addProcess(pid, processInfo) {
+    activeProcesses[pid] = {
+      pid,
+      port: processInfo.port,
+      projectId: processInfo.projectId,
+      startTime: Date.now(),
+      command: processInfo.command,
+      cwd: processInfo.cwd
+    };
+    persistProcesses();
+    console.log(`➕ Added Documental process to tracking: PID ${pid}, Port ${processInfo.port}`);
+    return getProcess(pid);
+  }
+
+  function removeProcess(pid) {
+    if (activeProcesses[pid]) {
+      delete activeProcesses[pid];
+      persistProcesses();
+      console.log(`➖ Removed Documental process from tracking: PID ${pid}`);
+      return true;
+    }
+    return false;
+  }
+
+  function updateProcess(pid, updates) {
+    if (!activeProcesses[pid]) {
+      return false;
+    }
+
+    activeProcesses[pid] = {
+      ...activeProcesses[pid],
+      ...updates
+    };
+    persistProcesses();
+    return true;
+  }
+
+  function getProcess(pid) {
+    const process = activeProcesses[pid];
+    return process ? { ...process } : undefined;
+  }
+
+  function hasProcess(pid) {
+    return Boolean(activeProcesses[pid]);
+  }
+
+  function getProcessesSnapshot() {
+    return Object.fromEntries(
+      Object.entries(activeProcesses).map(([pid, info]) => [pid, { ...info }])
+    );
+  }
+
+  function getProcessList() {
+    return Object.values(activeProcesses).map(info => ({ ...info }));
+  }
+
+  return {
+    filePath,
+    loadProcesses,
+    addProcess,
+    removeProcess,
+    updateProcess,
+    getProcess,
+    hasProcess,
+    getProcessesSnapshot,
+    getProcessList
+  };
+}
+
+module.exports = {
+  createDocumentalTracker
+};

--- a/tests/main/bootstrapApp.test.cjs
+++ b/tests/main/bootstrapApp.test.cjs
@@ -1,0 +1,39 @@
+const { describe, it, expect, vi } = require('vitest');
+const { bootstrapApp } = require('../../src/main/bootstrap/app');
+
+describe('bootstrapApp', () => {
+  it('wires the Electron lifecycle and delegates to the provided callbacks', async () => {
+    const app = {
+      whenReady: vi.fn(() => Promise.resolve()),
+      on: vi.fn()
+    };
+    const createWindow = vi.fn();
+    const initializeDatabase = vi.fn();
+    const registerHandlers = vi.fn();
+    const onActivate = vi.fn();
+    const onBeforeQuit = vi.fn();
+    const onWindowAllClosed = vi.fn();
+
+    bootstrapApp({
+      app,
+      createWindow,
+      initializeDatabase,
+      registerHandlers,
+      onActivate,
+      onBeforeQuit,
+      onWindowAllClosed
+    });
+
+    expect(app.whenReady).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+
+    expect(createWindow).toHaveBeenCalledTimes(1);
+    expect(initializeDatabase).toHaveBeenCalledTimes(1);
+    expect(registerHandlers).toHaveBeenCalledTimes(1);
+
+    expect(app.on).toHaveBeenCalledWith('activate', onActivate);
+    expect(app.on).toHaveBeenCalledWith('before-quit', onBeforeQuit);
+    expect(app.on).toHaveBeenCalledWith('window-all-closed', onWindowAllClosed);
+  });
+});

--- a/tests/main/documentalTracker.test.cjs
+++ b/tests/main/documentalTracker.test.cjs
@@ -1,0 +1,85 @@
+const { describe, it, expect, beforeEach, vi } = require('vitest');
+const { createDocumentalTracker } = require('../../src/main/processes/documentalTracker');
+
+describe('createDocumentalTracker', () => {
+  let fsMock;
+  let pathMock;
+  beforeEach(() => {
+    fsMock = {
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(() => ''),
+      writeFileSync: vi.fn()
+    };
+    pathMock = {
+      join: (...parts) => parts.join('/')
+    };
+  });
+
+  it('loads processes from disk when the persistence file exists', () => {
+    const storedProcesses = {
+      10: { pid: 10, port: 3333 }
+    };
+
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(JSON.stringify(storedProcesses));
+
+    const tracker = createDocumentalTracker({
+      fs: fsMock,
+      path: pathMock,
+      processesFilePath: '/tmp/documental.json'
+    });
+
+    const processes = tracker.loadProcesses();
+
+    expect(processes).toEqual(storedProcesses);
+  });
+
+  it('adds, updates and removes processes while persisting data to disk', () => {
+    const tracker = createDocumentalTracker({
+      fs: fsMock,
+      path: pathMock,
+      processesFilePath: '/tmp/documental.json'
+    });
+
+    tracker.addProcess(20, {
+      port: null,
+      projectId: 'alpha',
+      command: 'npm run dev',
+      cwd: '/projects/alpha'
+    });
+
+    expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
+
+    const addedProcess = tracker.getProcess(20);
+    expect(addedProcess).toMatchObject({ pid: 20, projectId: 'alpha', command: 'npm run dev' });
+
+    tracker.updateProcess(20, { port: 4321 });
+    const updatedProcess = tracker.getProcess(20);
+    expect(updatedProcess.port).toBe(4321);
+
+    tracker.removeProcess(20);
+    expect(tracker.getProcess(20)).toBeUndefined();
+    expect(fsMock.writeFileSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns snapshots without exposing internal references', () => {
+    const tracker = createDocumentalTracker({
+      fs: fsMock,
+      path: pathMock,
+      processesFilePath: '/tmp/documental.json'
+    });
+
+    tracker.addProcess(30, {
+      port: 5555,
+      projectId: 'beta',
+      command: 'npm run dev',
+      cwd: '/projects/beta'
+    });
+
+    const snapshot = tracker.getProcessesSnapshot();
+    snapshot[30].projectId = 'mutated';
+
+    const original = tracker.getProcess(30);
+    expect(original.projectId).toBe('beta');
+  });
+});

--- a/tests/main/main-delegation.test.cjs
+++ b/tests/main/main-delegation.test.cjs
@@ -1,0 +1,44 @@
+const { describe, it, expect, vi } = require('vitest');
+
+const createLoggerMock = vi.fn(() => ({ getAppLogs: vi.fn() }));
+const createDocumentalTrackerMock = vi.fn(() => ({
+  addProcess: vi.fn(),
+  removeProcess: vi.fn(),
+  updateProcess: vi.fn(),
+  hasProcess: vi.fn(() => false),
+  loadProcesses: vi.fn(),
+  getProcessList: vi.fn(() => [])
+}));
+const bootstrapAppMock = vi.fn();
+
+vi.mock('../../src/main/logging/logger', () => ({ createLogger: createLoggerMock }));
+vi.mock('../../src/main/processes/documentalTracker', () => ({ createDocumentalTracker: createDocumentalTrackerMock }));
+vi.mock('../../src/main/bootstrap/app', () => ({ bootstrapApp: bootstrapAppMock }));
+
+const { loadMainProcess, electronMock } = require('../setup/helpers.cjs');
+
+describe('main process delegation', () => {
+  it('delegates startup responsibilities to dedicated modules', () => {
+    loadMainProcess();
+
+    expect(createLoggerMock).toHaveBeenCalledWith({ BrowserWindow: electronMock.BrowserWindow });
+    expect(createDocumentalTrackerMock).toHaveBeenCalledWith(expect.objectContaining({
+      fs: expect.any(Object),
+      path: expect.any(Object),
+      processesFilePath: expect.any(String)
+    }));
+    expect(bootstrapAppMock).toHaveBeenCalledTimes(1);
+
+    const bootstrapArgs = bootstrapAppMock.mock.calls[0][0];
+
+    expect(typeof bootstrapArgs.registerHandlers).toBe('function');
+    expect(typeof bootstrapArgs.onActivate).toBe('function');
+    expect(typeof bootstrapArgs.onBeforeQuit).toBe('function');
+    expect(typeof bootstrapArgs.onWindowAllClosed).toBe('function');
+
+    bootstrapArgs.registerHandlers();
+
+    expect(electronMock.ipcMain.handle).toHaveBeenCalledWith('get-home-directory', expect.any(Function));
+    expect(electronMock.ipcMain.handle).toHaveBeenCalledWith('get-app-logs', expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- extract the main-process logging system into src/main/logging/logger.js
- introduce a dependency-injected Documental tracker module and consume it from main.js
- add a bootstrap helper that wires Electron lifecycle events and update main.js to delegate to it
- expand the Vitest suite with coverage for the new modules and main-process delegation

## Testing
- npm test *(fails: vitest binary is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691090ff64448333afd357699cb0a598)