### PR TITLE
Refactor main process around domain services

### DIFF
--- a/src/application/gitWorkflowService.js
+++ b/src/application/gitWorkflowService.js
@@ -1,0 +1,85 @@
+function createGitWorkflowService({ gitAdapter, projectService } = {}) {
+  if (!gitAdapter) {
+    throw new Error('gitAdapter is required');
+  }
+
+  if (!projectService) {
+    throw new Error('projectService is required');
+  }
+
+  async function withProject(projectId, handler) {
+    const project = await projectService.getProjectDetails(projectId);
+    const repositoryPath = projectService.resolveProjectRepositoryPath(project);
+    return handler(project, repositoryPath);
+  }
+
+  async function listBranches(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.listBranches(repositoryPath);
+    });
+  }
+
+  async function createBranch(projectId, branchName) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.createBranch(repositoryPath, branchName);
+    });
+  }
+
+  async function checkoutBranch(projectId, branchName) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.checkoutBranch(repositoryPath, branchName);
+    });
+  }
+
+  async function getCurrentBranch(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.getCurrentBranch(repositoryPath);
+    });
+  }
+
+  async function getRepositoryInfo(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.getRepositoryInfo(repositoryPath);
+    });
+  }
+
+  async function pullFromPreview(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.pullFromPreview(repositoryPath);
+    });
+  }
+
+  async function pushToBranch(projectId, targetBranch) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.pushToBranch(repositoryPath, targetBranch);
+    });
+  }
+
+  async function listRemoteBranches(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.listRemoteBranches(repositoryPath);
+    });
+  }
+
+  async function ensurePreviewBranch(projectId) {
+    return withProject(projectId, async (_project, repositoryPath) => {
+      return gitAdapter.ensurePreviewBranch(repositoryPath);
+    });
+  }
+
+  return {
+    listBranches,
+    createBranch,
+    checkoutBranch,
+    getCurrentBranch,
+    getRepositoryInfo,
+    pullFromPreview,
+    pushToBranch,
+    listRemoteBranches,
+    ensurePreviewBranch
+  };
+}
+
+module.exports = {
+  createGitWorkflowService
+};

--- a/src/application/nodeEnvironmentService.js
+++ b/src/application/nodeEnvironmentService.js
@@ -1,0 +1,60 @@
+function createNodeEnvironmentService({ nodeAdapter, projectService } = {}) {
+  if (!nodeAdapter) {
+    throw new Error('nodeAdapter is required');
+  }
+
+  if (!projectService) {
+    throw new Error('projectService is required');
+  }
+
+  async function resolveProjectPath(projectId) {
+    const project = await projectService.getProjectDetails(projectId);
+    return projectService.resolveProjectRepositoryPath(project);
+  }
+
+  async function installDependencies(projectId, options = {}) {
+    const cwd = await resolveProjectPath(projectId);
+    return nodeAdapter.run('npm', ['install'], { cwd, ...options });
+  }
+
+  async function runBuild(projectId, options = {}) {
+    const cwd = await resolveProjectPath(projectId);
+    return nodeAdapter.run('npm', ['run', 'build'], { cwd, ...options });
+  }
+
+  function startDevServer(projectId, { script = 'dev', onStdout, onStderr, ...options } = {}) {
+    return resolveProjectPath(projectId).then(cwd => {
+      const child = nodeAdapter.spawn('npm', ['run', script], { cwd, ...options });
+
+      if (child && child.stdout && typeof child.stdout.on === 'function' && typeof onStdout === 'function') {
+        child.stdout.on('data', onStdout);
+      }
+
+      if (child && child.stderr && typeof child.stderr.on === 'function' && typeof onStderr === 'function') {
+        child.stderr.on('data', onStderr);
+      }
+
+      return child;
+    });
+  }
+
+  async function runScript(projectId, script, options = {}) {
+    if (typeof script !== 'string' || script.trim() === '') {
+      throw new Error('Script name is required');
+    }
+
+    const cwd = await resolveProjectPath(projectId);
+    return nodeAdapter.run('npm', ['run', script.trim()], { cwd, ...options });
+  }
+
+  return {
+    installDependencies,
+    runBuild,
+    startDevServer,
+    runScript
+  };
+}
+
+module.exports = {
+  createNodeEnvironmentService
+};

--- a/src/application/projectService.js
+++ b/src/application/projectService.js
@@ -1,0 +1,108 @@
+const { createProject, assignRepositoryFolder } = require('../domain/entities/project');
+const { validateProjectInput, buildRepositoryPath } = require('../domain/rules/projectRules');
+
+function createProjectService({ projectRepository, pathUtils } = {}) {
+  if (!projectRepository) {
+    throw new Error('projectRepository is required');
+  }
+
+  const joinFn = pathUtils && typeof pathUtils.join === 'function'
+    ? pathUtils.join.bind(pathUtils)
+    : undefined;
+
+  async function registerProject(projectData) {
+    validateProjectInput(projectData);
+
+    const existing = await projectRepository.findByProjectPath(projectData.projectPath.trim());
+    if (existing) {
+      throw new Error('PROJECT_ALREADY_EXISTS');
+    }
+
+    const project = createProject({
+      name: projectData.projectName,
+      githubUrl: projectData.githubUrl,
+      projectPath: projectData.projectPath
+    });
+
+    const savedProject = await projectRepository.save(project);
+    return savedProject;
+  }
+
+  async function getProjectById(projectId) {
+    if (!projectId) {
+      throw new Error('Project id is required');
+    }
+
+    return projectRepository.findById(projectId);
+  }
+
+  async function getProjectDetails(projectId) {
+    const project = await getProjectById(projectId);
+    if (!project) {
+      throw new Error('PROJECT_NOT_FOUND');
+    }
+    return project;
+  }
+
+  async function listRecentProjects(limit = 3) {
+    return projectRepository.findRecent(limit);
+  }
+
+  async function listAllProjects() {
+    return projectRepository.findAll();
+  }
+
+  function resolveProjectRepositoryPath(project) {
+    return buildRepositoryPath(project, joinFn);
+  }
+
+  async function setRepositoryFolder(projectId, repoFolderName) {
+    const project = await getProjectDetails(projectId);
+
+    const updatedProject = assignRepositoryFolder(project, repoFolderName);
+
+    // Ensure no other project shares the same absolute path
+    const absolutePath = resolveProjectRepositoryPath(updatedProject);
+    const conflicting = await findProjectByAbsolutePath(absolutePath);
+    if (conflicting && conflicting.id !== projectId) {
+      throw new Error('PROJECT_PATH_CONFLICT');
+    }
+
+    await projectRepository.update(updatedProject);
+    return updatedProject;
+  }
+
+  async function removeProject(projectId) {
+    const project = await getProjectById(projectId);
+    if (!project) {
+      return false;
+    }
+
+    await projectRepository.delete(projectId);
+    return true;
+  }
+
+  async function findProjectByAbsolutePath(absolutePath) {
+    const projects = await projectRepository.findAll();
+    return projects.find(project => {
+      const repositoryPath = resolveProjectRepositoryPath(project);
+      return repositoryPath === absolutePath || project.projectPath === absolutePath;
+    }) || null;
+  }
+
+  return {
+    registerProject,
+    getProjectById,
+    getProjectDetails,
+    listRecentProjects,
+    listAllProjects,
+    setRepositoryFolder,
+    removeProject,
+    findProjectByAbsolutePath,
+    resolveProjectRepositoryPath
+  };
+}
+
+module.exports = {
+  createProjectService
+};

--- a/src/domain/entities/gitRepository.js
+++ b/src/domain/entities/gitRepository.js
@@ -1,0 +1,43 @@
+function createGitRepository({
+  remoteUrl = null,
+  currentBranch = null,
+  branches = []
+} = {}) {
+  return {
+    remoteUrl,
+    currentBranch,
+    branches: Array.isArray(branches) ? [...branches] : []
+  };
+}
+
+function updateCurrentBranch(repository, branchName) {
+  if (typeof branchName !== 'string' || branchName.trim() === '') {
+    throw new Error('Branch name is required');
+  }
+
+  return {
+    ...repository,
+    currentBranch: branchName.trim()
+  };
+}
+
+function addBranch(repository, branchName) {
+  if (typeof branchName !== 'string' || branchName.trim() === '') {
+    throw new Error('Branch name is required');
+  }
+
+  const normalized = branchName.trim();
+  const branches = new Set(repository.branches || []);
+  branches.add(normalized);
+
+  return {
+    ...repository,
+    branches: [...branches]
+  };
+}
+
+module.exports = {
+  createGitRepository,
+  updateCurrentBranch,
+  addBranch
+};

--- a/src/domain/entities/nodeEnvironment.js
+++ b/src/domain/entities/nodeEnvironment.js
@@ -1,0 +1,21 @@
+function createNodeEnvironment({
+  nodePath = 'node',
+  packageManager = 'npm'
+} = {}) {
+  if (typeof nodePath !== 'string' || nodePath.trim() === '') {
+    throw new Error('Node path is required');
+  }
+
+  if (typeof packageManager !== 'string' || packageManager.trim() === '') {
+    throw new Error('Package manager is required');
+  }
+
+  return {
+    nodePath: nodePath.trim(),
+    packageManager: packageManager.trim()
+  };
+}
+
+module.exports = {
+  createNodeEnvironment
+};

--- a/src/domain/entities/project.js
+++ b/src/domain/entities/project.js
@@ -1,0 +1,50 @@
+function assertString(value, message) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(message);
+  }
+}
+
+function createProject({
+  id = null,
+  name,
+  projectPath,
+  githubUrl,
+  repoFolderName = null,
+  createdAt = null
+} = {}) {
+  assertString(name, 'Project name is required');
+  assertString(projectPath, 'Project path is required');
+  assertString(githubUrl, 'GitHub URL is required');
+
+  const trimmedRepoFolderName = repoFolderName && repoFolderName.trim() !== ''
+    ? repoFolderName.trim()
+    : null;
+
+  return {
+    id,
+    name: name.trim(),
+    projectPath: projectPath.trim(),
+    githubUrl: githubUrl.trim(),
+    repoFolderName: trimmedRepoFolderName,
+    createdAt: createdAt || new Date().toISOString()
+  };
+}
+
+function assignRepositoryFolder(project, repoFolderName) {
+  assertString(repoFolderName, 'Repository folder name is required');
+
+  return {
+    ...project,
+    repoFolderName: repoFolderName.trim()
+  };
+}
+
+function hasRepositoryFolder(project) {
+  return Boolean(project.repoFolderName && project.repoFolderName.trim() !== '');
+}
+
+module.exports = {
+  createProject,
+  assignRepositoryFolder,
+  hasRepositoryFolder
+};

--- a/src/domain/rules/projectRules.js
+++ b/src/domain/rules/projectRules.js
@@ -1,0 +1,45 @@
+const PATH_SEPARATOR_REGEX = /[\\/]+/g;
+
+function validateProjectInput({ projectName, githubUrl, projectPath } = {}) {
+  if (typeof projectName !== 'string' || projectName.trim() === '') {
+    throw new Error('Project name is required');
+  }
+
+  if (typeof githubUrl !== 'string' || githubUrl.trim() === '') {
+    throw new Error('GitHub URL is required');
+  }
+
+  if (typeof projectPath !== 'string' || projectPath.trim() === '') {
+    throw new Error('Project path is required');
+  }
+}
+
+function normalizePath(pathValue) {
+  if (typeof pathValue !== 'string') {
+    return pathValue;
+  }
+
+  return pathValue.replace(PATH_SEPARATOR_REGEX, '/');
+}
+
+function buildRepositoryPath(project, joinFn) {
+  if (!project || typeof project !== 'object') {
+    throw new Error('Project is required');
+  }
+
+  const join = typeof joinFn === 'function'
+    ? joinFn
+    : ((base, segment) => `${base.replace(/[\\/]+$/, '')}/${segment}`);
+
+  if (!project.repoFolderName) {
+    return project.projectPath;
+  }
+
+  return join(project.projectPath, project.repoFolderName);
+}
+
+module.exports = {
+  validateProjectInput,
+  normalizePath,
+  buildRepositoryPath
+};

--- a/src/infrastructure/database/sqliteProjectRepository.js
+++ b/src/infrastructure/database/sqliteProjectRepository.js
@@ -1,0 +1,131 @@
+const { createProject } = require('../../domain/entities/project');
+
+function createSqliteProjectRepository({ db } = {}) {
+  if (!db || typeof db.run !== 'function') {
+    throw new Error('A sqlite database instance is required');
+  }
+
+  function run(sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.run(sql, params, function callback(err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(this);
+        }
+      });
+    });
+  }
+
+  function get(sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.get(sql, params, (err, row) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(row);
+        }
+      });
+    });
+  }
+
+  function all(sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.all(sql, params, (err, rows) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(rows);
+        }
+      });
+    });
+  }
+
+  function mapRowToProject(row) {
+    if (!row) {
+      return null;
+    }
+
+    return createProject({
+      id: row.id,
+      name: row.projectName,
+      projectPath: row.projectPath,
+      githubUrl: row.githubUrl,
+      repoFolderName: row.repoFolderName,
+      createdAt: row.createdAt
+    });
+  }
+
+  async function initialize() {
+    await run(`CREATE TABLE IF NOT EXISTS projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      projectName TEXT NOT NULL,
+      githubUrl TEXT NOT NULL,
+      projectPath TEXT NOT NULL,
+      repoFolderName TEXT,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+  }
+
+  async function save(project) {
+    const result = await run(
+      `INSERT INTO projects (projectName, githubUrl, projectPath, repoFolderName) VALUES (?, ?, ?, ?)` ,
+      [project.name, project.githubUrl, project.projectPath, project.repoFolderName]
+    );
+
+    const row = await get(`SELECT * FROM projects WHERE id = ?`, [result.lastID]);
+    return mapRowToProject(row);
+  }
+
+  async function update(project) {
+    await run(
+      `UPDATE projects SET projectName = ?, githubUrl = ?, projectPath = ?, repoFolderName = ? WHERE id = ?`,
+      [project.name, project.githubUrl, project.projectPath, project.repoFolderName, project.id]
+    );
+
+    const row = await get(`SELECT * FROM projects WHERE id = ?`, [project.id]);
+    return mapRowToProject(row);
+  }
+
+  async function remove(projectId) {
+    await run(`DELETE FROM projects WHERE id = ?`, [projectId]);
+  }
+
+  async function findById(projectId) {
+    const row = await get(`SELECT * FROM projects WHERE id = ?`, [projectId]);
+    return mapRowToProject(row);
+  }
+
+  async function findRecent(limit = 3) {
+    const rows = await all(
+      `SELECT * FROM projects ORDER BY datetime(createdAt) DESC LIMIT ?`,
+      [limit]
+    );
+    return rows.map(mapRowToProject);
+  }
+
+  async function findAll() {
+    const rows = await all(`SELECT * FROM projects ORDER BY datetime(createdAt) DESC`);
+    return rows.map(mapRowToProject);
+  }
+
+  async function findByProjectPath(projectPath) {
+    const row = await get(`SELECT * FROM projects WHERE projectPath = ?`, [projectPath]);
+    return mapRowToProject(row);
+  }
+
+  return {
+    initialize,
+    save,
+    update,
+    delete: remove,
+    findById,
+    findRecent,
+    findAll,
+    findByProjectPath
+  };
+}
+
+module.exports = {
+  createSqliteProjectRepository
+};

--- a/src/infrastructure/git/isomorphicGitAdapter.js
+++ b/src/infrastructure/git/isomorphicGitAdapter.js
@@ -1,0 +1,418 @@
+function createIsomorphicGitAdapter({ git, http, fs, getGitHubToken, sendCommandOutput } = {}) {
+  if (!git) {
+    throw new Error('git implementation is required');
+  }
+
+  if (!fs) {
+    throw new Error('fs implementation is required');
+  }
+
+  const output = typeof sendCommandOutput === 'function' ? sendCommandOutput : () => {};
+
+  async function clone(url, dir, options = {}) {
+    try {
+      const token = getGitHubToken ? await getGitHubToken() : null;
+      const auth = token ? { username: token, password: 'x-oauth-basic' } : undefined;
+
+      await git.clone({
+        fs,
+        http,
+        dir,
+        url,
+        auth,
+        ...options
+      });
+
+      return true;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async function checkout(dir, branch) {
+    await git.checkout({
+      fs,
+      dir,
+      ref: branch
+    });
+    return true;
+  }
+
+  async function getRemoteUrl(dir) {
+    try {
+      const url = await git.getConfig({
+        fs,
+        dir,
+        path: 'remote.origin.url'
+      });
+      return url;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async function setUserConfig(dir, name, email) {
+    await git.setConfig({
+      fs,
+      dir,
+      path: 'user.name',
+      value: name
+    });
+
+    await git.setConfig({
+      fs,
+      dir,
+      path: 'user.email',
+      value: email
+    });
+
+    return true;
+  }
+
+  async function listBranches(dir) {
+    try {
+      output(`📋 Listando branches em ${dir}...\n`);
+      const branches = await git.listBranches({ fs, dir });
+      output(`🔍 Encontradas ${branches.length} branches no repositório\n`);
+
+      const currentBranch = await git.currentBranch({ fs, dir });
+      output(`📍 Branch atual: ${currentBranch}\n`);
+
+      const localBranches = branches.filter(branch => !branch.includes('origin/'));
+      const remoteBranches = branches.filter(branch => branch.includes('origin/'))
+        .map(branch => branch.replace('origin/', ''));
+
+      const uniqueBranches = [...new Set([...localBranches, ...remoteBranches])];
+
+      output(`📂 Branches locais: ${localBranches.length}\n`);
+      output(`🌐 Branches remotas: ${remoteBranches.length}\n`);
+      output(`✅ Total de ${uniqueBranches.length} branches únicas\n`);
+
+      return {
+        branches: uniqueBranches,
+        currentBranch,
+        localBranches,
+        remoteBranches
+      };
+    } catch (error) {
+      output(`❌ Erro ao listar branches: ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function createBranch(dir, branchName) {
+    try {
+      output(`🌿 Criando nova branch '${branchName}' em ${dir}...\n`);
+
+      if (!branchName || !/^[a-zA-Z0-9._-]+$/.test(branchName)) {
+        throw new Error('Invalid branch name. Only alphanumeric characters, dots, hyphens and underscores are allowed.');
+      }
+
+      output(`🔍 Verificando se branch já existe...\n`);
+      const existingBranches = await git.listBranches({ fs, dir });
+      if (existingBranches.includes(branchName)) {
+        output(`❌ Branch '${branchName}' já existe.\n`);
+        throw new Error(`Branch '${branchName}' already exists.`);
+      }
+
+      output(`📝 Criando branch '${branchName}'...\n`);
+      await git.branch({
+        fs,
+        dir,
+        ref: branchName
+      });
+
+      output(`🔄 Mudando para nova branch '${branchName}'...\n`);
+      await git.checkout({
+        fs,
+        dir,
+        ref: branchName
+      });
+
+      output(`✅ Branch '${branchName}' criada e selecionada com sucesso\n`);
+      return true;
+    } catch (error) {
+      output(`❌ Erro ao criar branch '${branchName}': ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function checkoutBranch(dir, branchName) {
+    try {
+      output(`🔄 Mudando para branch '${branchName}' em ${dir}...\n`);
+
+      const branches = await git.listBranches({ fs, dir });
+      const localBranch = branches.find(b => b === branchName);
+      const remoteBranch = branches.find(b => b === `origin/${branchName}`);
+
+      if (!localBranch && !remoteBranch) {
+        output(`❌ Branch '${branchName}' não encontrada.\n`);
+        throw new Error(`Branch '${branchName}' not found.`);
+      }
+
+      if (!localBranch && remoteBranch) {
+        output(`📥 Criando branch local '${branchName}' para rastrear branch remota\n`);
+        await git.branch({
+          fs,
+          dir,
+          ref: branchName,
+          checkout: true
+        });
+      } else {
+        output(`📂 Selecionando branch local existente '${branchName}'\n`);
+        await git.checkout({
+          fs,
+          dir,
+          ref: branchName
+        });
+      }
+
+      output(`✅ Branch '${branchName}' selecionada com sucesso\n`);
+      return true;
+    } catch (error) {
+      output(`❌ Erro ao selecionar branch '${branchName}': ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function getCurrentBranch(dir) {
+    return git.currentBranch({ fs, dir });
+  }
+
+  async function ensurePreviewBranch(dir) {
+    try {
+      output(`🔍 Garantindo que a branch 'preview' exista em ${dir}...\n`);
+
+      const branches = await git.listBranches({ fs, dir });
+      const hasLocalPreview = branches.includes('preview');
+      const hasRemotePreview = branches.includes('origin/preview');
+
+      output(`📂 Branch 'preview' local: ${hasLocalPreview ? '✅' : '❌'}\n`);
+      output(`🌐 Branch 'preview' remota: ${hasRemotePreview ? '✅' : '❌'}\n`);
+
+      if (hasLocalPreview || hasRemotePreview) {
+        output(`📂 Branch 'preview' encontrada (${hasLocalPreview ? 'local' : 'remota'}), selecionando...\n`);
+        await checkoutBranch(dir, 'preview');
+        output(`✅ Branch 'preview' selecionada com sucesso\n`);
+        return { created: false, checkedOut: true, source: hasLocalPreview ? 'local' : 'remote' };
+      }
+
+      let baseBranch = 'main';
+      try {
+        output(`🔍 Tentando selecionar branch 'main' como base...\n`);
+        await checkoutBranch(dir, 'main');
+      } catch (mainError) {
+        output(`⚠️ Branch 'main' não encontrada: ${mainError.message}\n`);
+        try {
+          output(`🔍 Tentando selecionar branch 'master' como base...\n`);
+          await checkoutBranch(dir, 'master');
+          baseBranch = 'master';
+        } catch (masterError) {
+          output(`❌ Branch 'master' também não encontrada: ${masterError.message}\n`);
+          throw new Error('Nem branch "main" nem "master" encontrada para criar a branch "preview"');
+        }
+      }
+
+      try {
+        const status = await git.status({ fs, dir });
+        if (status.files && status.files.length > 0) {
+          output(`⚠️ Existem arquivos não commitados no diretório de trabalho\n`);
+          output(`📋 Arquivos modificados: ${status.files.map(f => f.path).join(', ')}\n`);
+        } else {
+          output(`✅ Diretório de trabalho limpo, seguro para criar branch\n`);
+        }
+      } catch (statusError) {
+        output(`⚠️ Não foi possível verificar status do diretório: ${statusError.message}\n`);
+      }
+
+      output(`🌿 Criando branch 'preview' a partir de '${baseBranch}'...\n`);
+      await createBranch(dir, 'preview');
+
+      try {
+        const remoteUrl = await getRemoteUrl(dir);
+        if (remoteUrl) {
+          output(`🌐 Repositório remoto encontrado: ${remoteUrl}\n`);
+          output(`🚀 Tentando publicar branch 'preview' para o repositório remoto...\n`);
+
+          const token = getGitHubToken ? await getGitHubToken() : null;
+          if (token) {
+            const auth = { username: token, password: 'x-oauth-basic' };
+            await git.push({
+              fs,
+              http,
+              dir,
+              url: remoteUrl,
+              ref: 'preview:preview',
+              auth,
+              force: false
+            });
+            output(`✅ Branch 'preview' publicada com sucesso para o repositório remoto\n`);
+          } else {
+            output(`⚠️ Autenticação GitHub não configurada\n`);
+          }
+        } else {
+          output(`ℹ️ Nenhum repositório remoto configurado\n`);
+        }
+      } catch (pushError) {
+        output(`⚠️ Não foi possível publicar branch 'preview' para o repositório remoto: ${pushError.message}\n`);
+      }
+
+      return { created: true, checkedOut: true, baseBranch };
+    } catch (error) {
+      output(`❌ Erro ao garantir branch 'preview': ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function getRepositoryInfo(dir) {
+    try {
+      let remoteUrl = '';
+      try {
+        remoteUrl = await git.getConfig({
+          fs,
+          dir,
+          path: 'remote.origin.url'
+        });
+      } catch (error) {
+        // ignore missing remote
+      }
+
+      const currentBranch = await git.currentBranch({ fs, dir });
+      const branches = await git.listBranches({ fs, dir });
+
+      return {
+        remoteUrl,
+        currentBranch,
+        branches
+      };
+    } catch (error) {
+      output(`❌ Error getting repository info: ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function pullFromPreview(dir) {
+    try {
+      output(`🔄 Buscando atualizações da branch preview em ${dir}...\n`);
+
+      const currentBranch = await git.currentBranch({ fs, dir });
+      output(`📍 Branch atual: ${currentBranch}\n`);
+
+      const token = getGitHubToken ? await getGitHubToken() : null;
+      const auth = token ? { username: token, password: 'x-oauth-basic' } : undefined;
+
+      output(`📥 Buscando dados da branch remota 'preview'...\n`);
+      await git.fetch({
+        fs,
+        http,
+        dir,
+        url: await getRemoteUrl(dir),
+        ref: 'preview',
+        auth,
+        singleBranch: false
+      });
+
+      output(`🔀 Mesclando origin/preview na branch ${currentBranch}...\n`);
+      await git.merge({
+        fs,
+        dir,
+        theirs: 'origin/preview',
+        ours: currentBranch,
+        message: `Merge preview into ${currentBranch}`
+      });
+
+      output(`✅ Branch 'preview' mesclada com sucesso em ${currentBranch}\n`);
+      return {
+        success: true,
+        message: `Atualizações da branch 'preview' foram mescladas na branch '${currentBranch}' com sucesso.`
+      };
+    } catch (error) {
+      output(`❌ Erro ao buscar atualizações: ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function pushToBranch(dir, targetBranch) {
+    try {
+      output(`🚀 Publicando de ${dir} para branch ${targetBranch}...\n`);
+
+      const currentBranch = await git.currentBranch({ fs, dir });
+      output(`📍 Branch atual: ${currentBranch}\n`);
+
+      const token = getGitHubToken ? await getGitHubToken() : null;
+      const auth = token ? { username: token, password: 'x-oauth-basic' } : undefined;
+
+      const remoteUrl = await getRemoteUrl(dir);
+      if (!remoteUrl) {
+        output(`❌ URL remota não encontrada.\n`);
+        throw new Error('Remote URL not found. Please ensure the repository has a remote origin.');
+      }
+
+      await git.push({
+        fs,
+        http,
+        dir,
+        url: remoteUrl,
+        ref: `${currentBranch}:${targetBranch}`,
+        auth,
+        force: false
+      });
+
+      output(`✅ Branch ${currentBranch} publicada com sucesso para ${targetBranch}\n`);
+      return {
+        success: true,
+        message: `Branch '${currentBranch}' foi publicada com sucesso para '${targetBranch}'.`
+      };
+    } catch (error) {
+      output(`❌ Erro ao publicar branch: ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  async function listRemoteBranches(dir) {
+    try {
+      output(`📋 Listando branches remotas em ${dir}...\n`);
+
+      const token = getGitHubToken ? await getGitHubToken() : null;
+      const auth = token ? { username: token, password: 'x-oauth-basic' } : undefined;
+
+      const remoteUrl = await getRemoteUrl(dir);
+      if (!remoteUrl) {
+        output(`❌ URL remota não encontrada.\n`);
+        throw new Error('Remote URL not found. Please ensure the repository has a remote origin.');
+      }
+
+      const result = await git.listBranches({
+        fs,
+        dir,
+        remote: 'origin'
+      });
+
+      output(`✅ Encontradas ${result.length} branches remotas\n`);
+      return result;
+    } catch (error) {
+      output(`❌ Erro ao listar branches remotas: ${error.message}\n`);
+      throw error;
+    }
+  }
+
+  return {
+    clone,
+    checkout,
+    getRemoteUrl,
+    setUserConfig,
+    listBranches,
+    createBranch,
+    checkoutBranch,
+    getCurrentBranch,
+    ensurePreviewBranch,
+    getRepositoryInfo,
+    pullFromPreview,
+    pushToBranch,
+    listRemoteBranches
+  };
+}
+
+module.exports = {
+  createIsomorphicGitAdapter
+};

--- a/src/infrastructure/node/nodeCommandAdapter.js
+++ b/src/infrastructure/node/nodeCommandAdapter.js
@@ -1,0 +1,57 @@
+function createNodeCommandAdapter({ spawn } = {}) {
+  if (typeof spawn !== 'function') {
+    throw new Error('spawn function is required');
+  }
+
+  function run(command, args = [], options = {}) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, options);
+      let stdout = '';
+      let stderr = '';
+
+      if (child.stdout && typeof child.stdout.on === 'function') {
+        child.stdout.on('data', data => {
+          stdout += data.toString();
+          if (typeof options.onStdout === 'function') {
+            options.onStdout(data);
+          }
+        });
+      }
+
+      if (child.stderr && typeof child.stderr.on === 'function') {
+        child.stderr.on('data', data => {
+          stderr += data.toString();
+          if (typeof options.onStderr === 'function') {
+            options.onStderr(data);
+          }
+        });
+      }
+
+      child.on('error', reject);
+      child.on('close', code => {
+        if (code === 0) {
+          resolve({ code, stdout, stderr });
+        } else {
+          const error = new Error(`Command failed with exit code ${code}`);
+          error.code = code;
+          error.stdout = stdout;
+          error.stderr = stderr;
+          reject(error);
+        }
+      });
+    });
+  }
+
+  function spawnProcess(command, args = [], options = {}) {
+    return spawn(command, args, options);
+  }
+
+  return {
+    run,
+    spawn: spawnProcess
+  };
+}
+
+module.exports = {
+  createNodeCommandAdapter
+};

--- a/tests/application/gitWorkflowService.test.cjs
+++ b/tests/application/gitWorkflowService.test.cjs
@@ -1,0 +1,79 @@
+const { describe, it, expect, beforeEach, vi } = require('vitest');
+const { createGitWorkflowService } = require('../../src/application/gitWorkflowService');
+const { createProject } = require('../../src/domain/entities/project');
+
+describe('GitWorkflowService', () => {
+  let gitAdapter;
+  let projectService;
+  let service;
+
+  beforeEach(() => {
+    gitAdapter = {
+      listBranches: vi.fn(async () => ({ branches: ['main'], currentBranch: 'main' })),
+      createBranch: vi.fn(async () => true),
+      checkoutBranch: vi.fn(async () => true),
+      getCurrentBranch: vi.fn(async () => 'main'),
+      getRepositoryInfo: vi.fn(async () => ({ remoteUrl: 'git@github.com:org/repo.git' })),
+      pullFromPreview: vi.fn(async () => ({ success: true })),
+      pushToBranch: vi.fn(async () => ({ success: true })),
+      listRemoteBranches: vi.fn(async () => ['preview', 'main']),
+      ensurePreviewBranch: vi.fn(async () => ({ created: false }))
+    };
+
+    const project = createProject({
+      id: 1,
+      name: 'Alpha',
+      projectPath: '/projects/alpha',
+      githubUrl: 'https://github.com/org/alpha',
+      repoFolderName: 'alpha'
+    });
+
+    projectService = {
+      getProjectDetails: vi.fn(async () => project),
+      resolveProjectRepositoryPath: vi.fn(() => '/projects/alpha/alpha')
+    };
+
+    service = createGitWorkflowService({ gitAdapter, projectService });
+  });
+
+  it('delegates branch listing to the git adapter', async () => {
+    const result = await service.listBranches(1);
+    expect(result.currentBranch).toBe('main');
+    expect(gitAdapter.listBranches).toHaveBeenCalledWith('/projects/alpha/alpha');
+  });
+
+  it('creates branches on the git adapter', async () => {
+    await service.createBranch(1, 'feature/alpha');
+    expect(gitAdapter.createBranch).toHaveBeenCalledWith('/projects/alpha/alpha', 'feature/alpha');
+  });
+
+  it('checks out branches using the git adapter', async () => {
+    await service.checkoutBranch(1, 'preview');
+    expect(gitAdapter.checkoutBranch).toHaveBeenCalledWith('/projects/alpha/alpha', 'preview');
+  });
+
+  it('retrieves repository info from the adapter', async () => {
+    await service.getRepositoryInfo(1);
+    expect(gitAdapter.getRepositoryInfo).toHaveBeenCalledWith('/projects/alpha/alpha');
+  });
+
+  it('pulls from preview branch through the adapter', async () => {
+    await service.pullFromPreview(1);
+    expect(gitAdapter.pullFromPreview).toHaveBeenCalledWith('/projects/alpha/alpha');
+  });
+
+  it('pushes to a target branch using the adapter', async () => {
+    await service.pushToBranch(1, 'preview');
+    expect(gitAdapter.pushToBranch).toHaveBeenCalledWith('/projects/alpha/alpha', 'preview');
+  });
+
+  it('lists remote branches using the adapter', async () => {
+    await service.listRemoteBranches(1);
+    expect(gitAdapter.listRemoteBranches).toHaveBeenCalledWith('/projects/alpha/alpha');
+  });
+
+  it('ensures preview branch exists using the adapter', async () => {
+    await service.ensurePreviewBranch(1);
+    expect(gitAdapter.ensurePreviewBranch).toHaveBeenCalledWith('/projects/alpha/alpha');
+  });
+});

--- a/tests/application/nodeEnvironmentService.test.cjs
+++ b/tests/application/nodeEnvironmentService.test.cjs
@@ -1,0 +1,55 @@
+const { describe, it, expect, beforeEach, vi } = require('vitest');
+const { createNodeEnvironmentService } = require('../../src/application/nodeEnvironmentService');
+const { createProject } = require('../../src/domain/entities/project');
+
+describe('NodeEnvironmentService', () => {
+  let nodeAdapter;
+  let projectService;
+  let service;
+
+  beforeEach(() => {
+    nodeAdapter = {
+      run: vi.fn(async () => ({ code: 0 })),
+      spawn: vi.fn(() => ({
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() }
+      }))
+    };
+
+    const project = createProject({
+      id: 7,
+      name: 'Gamma',
+      projectPath: '/projects/gamma',
+      githubUrl: 'https://github.com/org/gamma',
+      repoFolderName: 'app'
+    });
+
+    projectService = {
+      getProjectDetails: vi.fn(async () => project),
+      resolveProjectRepositoryPath: vi.fn(() => '/projects/gamma/app')
+    };
+
+    service = createNodeEnvironmentService({ nodeAdapter, projectService });
+  });
+
+  it('installs dependencies using the node adapter', async () => {
+    await service.installDependencies(7);
+    expect(nodeAdapter.run).toHaveBeenCalledWith('npm', ['install'], expect.objectContaining({ cwd: '/projects/gamma/app' }));
+  });
+
+  it('runs build scripts using the node adapter', async () => {
+    await service.runBuild(7);
+    expect(nodeAdapter.run).toHaveBeenCalledWith('npm', ['run', 'build'], expect.objectContaining({ cwd: '/projects/gamma/app' }));
+  });
+
+  it('spawns a dev server process using the node adapter', async () => {
+    const child = await service.startDevServer(7, { script: 'dev', onStdout: vi.fn(), onStderr: vi.fn() });
+    expect(nodeAdapter.spawn).toHaveBeenCalledWith('npm', ['run', 'dev'], expect.objectContaining({ cwd: '/projects/gamma/app' }));
+    expect(child).toBeDefined();
+  });
+
+  it('runs arbitrary scripts via npm', async () => {
+    await service.runScript(7, 'lint');
+    expect(nodeAdapter.run).toHaveBeenCalledWith('npm', ['run', 'lint'], expect.objectContaining({ cwd: '/projects/gamma/app' }));
+  });
+});

--- a/tests/application/projectService.test.cjs
+++ b/tests/application/projectService.test.cjs
@@ -1,0 +1,117 @@
+const { describe, it, expect, beforeEach, vi } = require('vitest');
+const path = require('path');
+const { createProjectService } = require('../../src/application/projectService');
+const { createProject } = require('../../src/domain/entities/project');
+
+describe('ProjectService', () => {
+  let repository;
+  let service;
+
+  beforeEach(() => {
+    repository = {
+      save: vi.fn(async project => ({ ...project, id: 10 })),
+      update: vi.fn(async project => project),
+      delete: vi.fn(async () => undefined),
+      findById: vi.fn(async id => (id === 10 ? createProject({
+        id: 10,
+        name: 'Alpha',
+        projectPath: '/projects/alpha',
+        githubUrl: 'https://github.com/org/alpha',
+        repoFolderName: 'alpha'
+      }) : null)),
+      findRecent: vi.fn(async limit => Array.from({ length: limit }, (_, index) => createProject({
+        id: index + 1,
+        name: `Project-${index}`,
+        projectPath: `/projects/${index}`,
+        githubUrl: 'https://example.com/repo'
+      }))),
+      findAll: vi.fn(async () => [
+        createProject({
+          id: 10,
+          name: 'Alpha',
+          projectPath: '/projects/alpha',
+          githubUrl: 'https://github.com/org/alpha',
+          repoFolderName: 'alpha'
+        }),
+        createProject({
+          id: 20,
+          name: 'Beta',
+          projectPath: '/projects/beta',
+          githubUrl: 'https://github.com/org/beta'
+        })
+      ]),
+      findByProjectPath: vi.fn(async projectPath => {
+        if (projectPath === '/projects/existing') {
+          return createProject({
+            id: 99,
+            name: 'Existing',
+            projectPath,
+            githubUrl: 'https://github.com/org/existing'
+          });
+        }
+        return null;
+      })
+    };
+
+    service = createProjectService({ projectRepository: repository, pathUtils: path });
+  });
+
+  it('registers a new project when no conflict exists', async () => {
+    const project = await service.registerProject({
+      projectName: 'New Project',
+      githubUrl: 'https://github.com/org/new',
+      projectPath: '/projects/new'
+    });
+
+    expect(repository.save).toHaveBeenCalled();
+    expect(project.id).toBe(10);
+  });
+
+  it('prevents registering projects with duplicate paths', async () => {
+    await expect(service.registerProject({
+      projectName: 'Existing',
+      githubUrl: 'https://github.com/org/existing',
+      projectPath: '/projects/existing'
+    })).rejects.toThrow('PROJECT_ALREADY_EXISTS');
+  });
+
+  it('calculates the repository path for a project', async () => {
+    const project = await service.getProjectDetails(10);
+    const repoPath = service.resolveProjectRepositoryPath(project);
+
+    expect(repoPath).toBe(path.join('/projects/alpha', 'alpha'));
+  });
+
+  it('updates the repository folder ensuring no conflicts', async () => {
+    repository.findAll.mockResolvedValueOnce([
+      createProject({
+        id: 10,
+        name: 'Alpha',
+        projectPath: '/projects/alpha',
+        githubUrl: 'https://github.com/org/alpha'
+      })
+    ]);
+
+    const updated = await service.setRepositoryFolder(10, 'alpha');
+    expect(updated.repoFolderName).toBe('alpha');
+    expect(repository.update).toHaveBeenCalled();
+  });
+
+  it('finds a project by its absolute path', async () => {
+    const project = await service.findProjectByAbsolutePath(path.join('/projects/alpha', 'alpha'));
+    expect(project).toBeDefined();
+    expect(project.name).toBe('Alpha');
+  });
+
+  it('removes a project when it exists', async () => {
+    const removed = await service.removeProject(10);
+    expect(removed).toBe(true);
+    expect(repository.delete).toHaveBeenCalledWith(10);
+  });
+
+  it('list recent projects honoring the provided limit', async () => {
+    const projects = await service.listRecentProjects(2);
+    expect(projects).toHaveLength(2);
+    expect(repository.findRecent).toHaveBeenCalledWith(2);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce domain entities and application services to manage projects, git workflows, and node environment tasks
- add sqlite, git, and node command adapters and wire them into the main process
- refactor project- and git-related IPC handlers to use the new services and add targeted unit tests for the services

## Testing
- `npm test` *(fails in this environment because vitest is unavailable without installing dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a9f77bb48333ac1f23ba9f96b8b2)